### PR TITLE
hw: remove baum.h #include from baum.c

### DIFF
--- a/hw/baum.c
+++ b/hw/baum.c
@@ -25,7 +25,6 @@
 #include "char/char.h"
 #include "qemu/timer.h"
 #include "usb.h"
-#include "baum.h"
 #include <brlapi.h>
 #include <brlapi_constants.h>
 #include <brlapi_keycodes.h>


### PR DESCRIPTION
commit 08744c "qemu-char: move baum registration to baum.c" removed
baum.h but forgot to remove the include in baum.c.

Signed-off-by: Sergio Correia sergio@correia.cc
