### PR TITLE
Fix: Add missing case for 24bit depth source image

### DIFF
--- a/hw/arm/bcm2835_fb.c
+++ b/hw/arm/bcm2835_fb.c
@@ -99,6 +99,13 @@ static void draw_line_src16(void *opaque, uint8_t *d, const uint8_t *s,
             b = ((rgb565 >>  0) & 0x1f) << 3;
             s += 2;
             break;
+        case 24:
+            rgb888 = ldl_raw(s);
+            r = (rgb888 >> 0) & 0xff;
+            g = (rgb888 >> 8) & 0xff;
+            b = (rgb888 >> 16) & 0xff;
+            s += 3;
+            break;
         case 32:
             rgb888 = ldl_raw(s);
             r = (rgb888 >> 0) & 0xff;


### PR DESCRIPTION
The case was missing for the read, caused the frame buffer to be completely black (default case).
