### PR TITLE
Fixes the compilation of ui/gtk.c

### DIFF
--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -1449,6 +1449,7 @@ static gboolean gd_vc_in(VteTerminal *terminal, gchar *text, guint size,
     return TRUE;
 }
 
+#if defined(CONFIG_VTE)
 static GSList *gd_vc_vte_init(GtkDisplayState *s, VirtualConsole *vc,
                               CharDriverState *chr, int idx,
                               GSList *group, GtkWidget *view_menu)


### PR DESCRIPTION
It seems a `#if` directive was missing because a `#endif` was alone. I used the "unknown reference" errors to find the right place for this directive and now the `make` works!
